### PR TITLE
set tes api page title for nav bar

### DIFF
--- a/website/pages/five_safes_tes/deploy/_meta.js
+++ b/website/pages/five_safes_tes/deploy/_meta.js
@@ -2,6 +2,7 @@ export default {
     deployment_submission:'Deploy Submission Layer',
     deployment_tre:'Deploy TRE Layer',
     install_funnel:'Install Funnel TES',
+    set_tesapi:'Set TES API',
     first_run:'Run your first analysis',
 
 }

--- a/website/pages/five_safes_tes/deploy/_meta.js
+++ b/website/pages/five_safes_tes/deploy/_meta.js
@@ -2,7 +2,7 @@ export default {
     deployment_submission:'Deploy Submission Layer',
     deployment_tre:'Deploy TRE Layer',
     install_funnel:'Install Funnel TES',
-    set_tesapi:'Set TES API',
+    set_tesapi:'Set TES API agent',
     first_run:'Run your first analysis',
 
 }


### PR DESCRIPTION
Set TES API page was missing from _meta.js so it was defaulting to the file name in the nav bar