### PR TITLE
Removal of Trellis as a name and also links to Planes

### DIFF
--- a/website/pages/_meta.js
+++ b/website/pages/_meta.js
@@ -1,7 +1,7 @@
 export default {
   index: {
     title: "Federated Research",
-    description: "Details of the implementations of Trellis weaves in the Health Data Research UK Programme",
+    description: "Details of the implementations of Federated Research Patterns and associated weaves in the Health Data Research UK Programme",
     theme: {
       breadcrumb: false,
       layout: 'full',
@@ -12,7 +12,7 @@ export default {
   },
   about_us: "About us",
   standards: "Standards",
-  trellis: "Trellis",
+  patterns: "Patterns",
   weaves: {
     title: "Weaves",
     type: "separator"

--- a/website/pages/egress.mdx
+++ b/website/pages/egress.mdx
@@ -14,7 +14,7 @@ The code for Egress is open source, and can be found on [Github](https://github.
 
 ## Use in Federated Research
 
-Egress is used within the [Five Safes TES](/five_safes_tes) weave, and is situated within the [Security Plane](/trellis/planes/security).
+Egress is used within the [Five Safes TES](/five_safes_tes) weave.
 
 ## Integration and Extensibility
 

--- a/website/pages/index.mdx
+++ b/website/pages/index.mdx
@@ -18,7 +18,7 @@ Federated Research is driven to transform how researchers securely access and an
 - Involvement with leading organisations to design and develop suitable research data infrastructure. These include HDR UK, DARE UK, ELIXIR, and EOSC
 - Collaborate with the public to promote transparency, garner acceptance and ensure operation within social licence
 
-#### Enable [Federation](/trellis)
+#### Enable [Federation](/patterns)
 - Federation is more than software or any specific platform. It's many, working together to form an ecosystem
 - Beyond technical possibilities, there are elements of trust, autonomy, and governance to inform what is acceptable and useful
 - There is no one-size-fits-all model of federation. How these networks are deployed is determined by trust, data maturity, technical infrastructure, and resources

--- a/website/pages/patterns.mdx
+++ b/website/pages/patterns.mdx
@@ -1,14 +1,14 @@
 import { Steps,Callout } from "nextra/components"
 
-# Trellis
+# Federated Research Patterns
 
 <Callout type="default">
     These concepts are still emerging, so get [in touch](https://federated-analytics.ac.uk/federated-analytics/community/) if you have feedback.
 </Callout>
 
-**Trellis** is a framework for defining and governing the components needed to support secure federation across Trusted Research Environments (TREs).
+**Federated Research Patterns** is a framework for defining and governing the components needed to support secure federation across Trusted Research Environments (TREs).
 
-Through the concept of **Weaves**, Trellis enables configurations of software, governance, and metadata,
+Through the concept of **Weaves**, Patterns enables configurations of software, governance, and metadata,
 supporting repeatable, standards-based federation for consortia and collaborative projects.
 
 ## Weaves
@@ -16,7 +16,7 @@ supporting repeatable, standards-based federation for consortia and collaborativ
 A **Weave** is a configuration that combines the description of software capability, governance, configuration, and metadata required for a model of federation.
 
 A Weave implementation enables a consistent description of federation capabilities.
-Weaves are used to implement Trellis, such as when a TRE consortium is formed and needs a consistent, standards-aligned description of a model of federation.
+Weaves are used to implement a Pattern, such as when a TRE consortium is formed and needs a consistent, standards-aligned description of a model of federation.
 
 Different Weaves provide different capability across a federated TRE, and is not software specific. 
 

--- a/website/pages/tre_agent.mdx
+++ b/website/pages/tre_agent.mdx
@@ -16,7 +16,7 @@ The code for TRE Agent is open source, and can be found on [Github](https://gith
 
 ## Use in Federated Research
 
-TRE Agent is used within the [Five Safes TES](/five_safes_tes) weave, and is situated within the [Control Plane](/trellis/planes/control).
+TRE Agent is used within the [Five Safes TES](/five_safes_tes) weave.
 
 ## Integration and Extensibility
 


### PR DESCRIPTION
Changes to rename Trellis to Patterns to avoid confusion with existing use of the word Trellis within a TRE. 

Removed links to Planes which we are not looking to do. 