### PR TITLE
Add docs about AppName config

### DIFF
--- a/website/pages/submission/deploy.mdx
+++ b/website/pages/submission/deploy.mdx
@@ -157,6 +157,12 @@ The descriptions of the essential environment variables and the guide to set the
       </Td>
     </Tr>
     <Tr>
+      <Td>`AppName`</Td>
+      <Td>
+        Name of the application shown on the Navigation bar of Submission Layer UI. Default is `Five Safes TES`.
+      </Td>
+    </Tr>
+    <Tr>
       <Td>`PGLOGIN` and `PGPASSWORD`</Td>
       <Td>
         The admin credentials for the PostgreSQL database used by the Submission

--- a/website/pages/tre_agent/deploy.mdx
+++ b/website/pages/tre_agent/deploy.mdx
@@ -215,6 +215,12 @@ The descriptions of the essential environment variables and the guide to set the
       </Td>
     </Tr>
     <Tr>
+      <Td>`AppName`</Td>
+      <Td>
+        Name of the application shown on the Navigation bar of TRE Agent UI. Default is `Five Safes TES`.
+      </Td>
+    </Tr>
+    <Tr>
       <Td>`PGLOGIN` and `PGPASSWORD`</Td>
       <Td>
         The admin credentials for the PostgreSQL database used by the TRE Agent.


### PR DESCRIPTION
This PR added the docs about the env var AppName, which is used to update the app name shown on the nav bar of the apps.