### PR TITLE
Deployment diagram streamlining 

### DIFF
--- a/website/likec4_src/context.c4
+++ b/website/likec4_src/context.c4
@@ -63,6 +63,5 @@ views {
     title '5Safes-TES - Context'
     description 'Top level diagram'
     include *
-    exclude revproxy, harbor, funnel, egress_admin, submission_admin
   }
 }

--- a/website/likec4_src/context.c4
+++ b/website/likec4_src/context.c4
@@ -62,6 +62,14 @@ views {
   view index {
     title '5Safes-TES - Context'
     description 'Top level diagram'
+
+    group '5S-TES' {
+      include submission
+      include tre
+      include egress
+      include execution
+    }
+
     include *
   }
 }

--- a/website/likec4_src/deployments/prod.c4
+++ b/website/likec4_src/deployments/prod.c4
@@ -3,16 +3,9 @@ model {
 }
 
 deployment {
-    environment prod {
-
-        vm1 = vm {
-            title 'External VM'
-        }
-
-        vm2 = vm {
-            title 'Internal VM'
-        }
-    }
+  environment prod {
+    vm1 = virtual_machine 'External VM'
+    vm2 = virtual_machine 'Internal VM'
 }
 
 

--- a/website/likec4_src/deployments/prod.c4
+++ b/website/likec4_src/deployments/prod.c4
@@ -1,16 +1,5 @@
 model {
-    submission -> tre 'Request job'
-
-    egress_admin = internal_actor {
-        title 'Egress Admin'
-        description 'Superuser responsible for validating the results of a job run on the TRE layer'
-    }
-
-    submission_admin = internal_actor {
-        title 'Submission Admin'
-        description 'Superuser responsible for submitting a job'
-    }
-
+  submission -> tre 'Request job'
 }
 
 deployment {

--- a/website/likec4_src/deployments/prod.c4
+++ b/website/likec4_src/deployments/prod.c4
@@ -15,11 +15,8 @@ deployment {
 
 
 views {
-    deployment view prod {
-        title 'Production Deployment'
-        link https://likec4.dev
-
-        include prod.**
-        // ...
-    }
+  deployment view prod {
+    title 'Production Deployment'
+    include prod.**
+  }
 }

--- a/website/likec4_src/deployments/prod.c4
+++ b/website/likec4_src/deployments/prod.c4
@@ -13,22 +13,6 @@ deployment {
             title 'Internal VM'
         }
 
-        instanceOf researcher {
-            -> vm1.revproxy 'Specify job'
-        }
-
-        instanceOf submission_admin {
-            -> vm1 'Administers'
-        }
-
-        instanceOf egress_admin {
-            -> vm2.egress 'Administers'
-        }
-
-        instanceOf tre_admin {
-            -> vm2.tre 'Administers'
-        }
-
         vm1.harbor -> vm2.tre 'Pull image'
 
         vm1.harbor -> vm2.egress 'Pull image'

--- a/website/likec4_src/deployments/prod.c4
+++ b/website/likec4_src/deployments/prod.c4
@@ -6,6 +6,11 @@ deployment {
   environment prod {
     vm1 = virtual_machine 'External VM'
     vm2 = virtual_machine 'Internal VM'
+    environment external_data {
+      title 'External data store'
+      instanceOf protected_data
+    }
+  }
 }
 
 

--- a/website/likec4_src/deployments/prod.c4
+++ b/website/likec4_src/deployments/prod.c4
@@ -12,11 +12,6 @@ deployment {
         vm2 = vm {
             title 'Internal VM'
         }
-
-        vm1.harbor -> vm2.tre 'Pull image'
-
-        vm1.harbor -> vm2.egress 'Pull image'
-
     }
 }
 

--- a/website/likec4_src/deployments/vms/external_vm.c4
+++ b/website/likec4_src/deployments/vms/external_vm.c4
@@ -1,0 +1,23 @@
+deployment {
+  extend prod.vm1 {
+    harbor = deploy_component {
+      title 'Harbor'
+      description 'Trusted container registry'
+      icon https://goharbor.io/img/logos/harbor-icon-color.png
+      
+      -> submission 'Pull images'
+      -> prod.tre 'Pull image'
+      -> prod.egress 'Pull image'
+    }
+
+    revproxy = deploy_component {
+      title 'Nginx'
+      description 'Reverse proxy for routing traffic to internal services'
+      icon tech:nginx
+
+      -> submission 'Route web traffic'
+    }
+
+    instanceOf submission
+  }
+}

--- a/website/likec4_src/deployments/vms/internal_vm.c4
+++ b/website/likec4_src/deployments/vms/internal_vm.c4
@@ -1,0 +1,7 @@
+deployment {
+  extend prod.vm2 {
+    instanceOf tre { style { multiple: true } }
+    instanceOf egress
+    instanceOf execution
+  }
+}

--- a/website/likec4_src/specs.c4
+++ b/website/likec4_src/specs.c4
@@ -1,11 +1,13 @@
 specification {
   element external_actor {
+    notation 'An external user of the system, no special priviledges'
     style {
       shape person
       color red
     }
   }
   element internal_actor {
+    notation 'A priviledged user with access to sustem internals'
     style {
       shape person
       color green
@@ -14,6 +16,7 @@ specification {
 
   color orange rgba(255, 153, 0, 100%)
   element database {
+    notation 'Data storage application'
     style {
       shape storage
       color orange
@@ -23,6 +26,7 @@ specification {
 
   color system-colour rgba(35, 67, 99, 100%)
   element system {
+    notation 'A group of applications arranged in a stack'
     style {
       color system-colour
     }
@@ -30,15 +34,16 @@ specification {
 
   color service-colour rgba(0, 100, 150, 100%)
   element service {
+    notation 'Complex applications with multiple components'
     style {
       color service-colour
     }
   }
 
-  color component-colour rgba(0, 0, 0, 100%)
   element component {
+    notation 'Individual applications'
     style {
-      color component-colour
+      color muted
     }
   }
 

--- a/website/likec4_src/specs.c4
+++ b/website/likec4_src/specs.c4
@@ -47,9 +47,12 @@ specification {
     }
   }
 
-  deploymentNode environment
-
-  deploymentNode vm {
-    notation 'Virtual Machine'
+  deploymentNode deploy_component {
+    notation 'Application from outside the 5S-TES'
+    style {
+      color orange
+    }
   }
+  deploymentNode environment
+  deploymentNode virtual_machine
 }


### PR DESCRIPTION
I made a few changes to make the deployment diagram more minimal visually and in the backend 

I added a bounding box to the context diagram and removed users from the deployment diagram

I ensured the likeC4 style for deployment was followed which removed the need for exclusions in the context 

I added some notations so users can use the help menu when browsing