### PR TITLE
Update docs with guide to set up Vault in prod. and new env vars.

### DIFF
--- a/website/pages/five_safes_tes/reference_implementation/TES/install_funnel.mdx
+++ b/website/pages/five_safes_tes/reference_implementation/TES/install_funnel.mdx
@@ -16,7 +16,7 @@ For the purposes of the All In One stack we will be configuring the TRE Agent to
   TRE Agent realm credentials.
 </Callout>
 
-Navigate to the MinIO instance of the TRE Layer (in DemoStack, it is hosted at: [localhost:9003](http://localhost:9003). If you are using a production deployment, the MinIO instance is hosted at: `<hostname>:9003`).
+Navigate to the MinIO instance of the TRE Layer. If you are using our deployment compose files as a starting point, it will be on the same host as the TRE Agent, at port 9003. If you've configured it to be different, you'll need to use the correct port.
 
 You can login with `Login with KeyCloak` option using the following credentials using your TRE admin credentials.
 

--- a/website/pages/five_safes_tes/reference_implementation/TES/install_funnel.mdx
+++ b/website/pages/five_safes_tes/reference_implementation/TES/install_funnel.mdx
@@ -16,8 +16,9 @@ For the purposes of the All In One stack we will be configuring the TRE Agent to
   TRE Agent realm credentials.
 </Callout>
 
-Navigate to the MinIO instance of the TRE Layer (hosted at: [localhost:9002](http://localhost:9002)).
-If you see the option to login with `SSO_Identifier`, use the following credentials:
+Navigate to the MinIO instance of the TRE Layer (in DemoStack, it is hosted at: [localhost:9003](http://localhost:9003). If you are using a production deployment, the MinIO instance is hosted at: `<hostname>:9003`).
+
+You can login with `Login with KeyCloak` option using the following credentials, if you are using DemoStack:
 
 ```yaml copy
 Username: globaladminuser

--- a/website/pages/five_safes_tes/reference_implementation/TES/install_funnel.mdx
+++ b/website/pages/five_safes_tes/reference_implementation/TES/install_funnel.mdx
@@ -18,19 +18,16 @@ For the purposes of the All In One stack we will be configuring the TRE Agent to
 
 Navigate to the MinIO instance of the TRE Layer (in DemoStack, it is hosted at: [localhost:9003](http://localhost:9003). If you are using a production deployment, the MinIO instance is hosted at: `<hostname>:9003`).
 
-You can login with `Login with KeyCloak` option using the following credentials, if you are using DemoStack:
+You can login with `Login with KeyCloak` option using the following credentials using your TRE admin credentials.
+
+If you are using DemoStack, the TRE admin credentials are:
 
 ```yaml copy
 Username: globaladminuser
 Password: password123
 ```
 
-You can also login to Minio with root credentials using the option `Use Credentials` under `Other Authentication methods`:
-
-```yaml copy
-Username: minio
-Password: minio123
-```
+You can also logig with Minio root credentials (set up in the environment variables) using the option `Use Credentials` under `Other Authentication methods`.
 
 To create the access keys, in the MinIO console navigate to **_Access Keys -> Create access key_**
 

--- a/website/pages/five_safes_tes/reference_implementation/TES/install_funnel.mdx
+++ b/website/pages/five_safes_tes/reference_implementation/TES/install_funnel.mdx
@@ -27,7 +27,7 @@ Username: globaladminuser
 Password: password123
 ```
 
-You can also logig with Minio root credentials (set up in the environment variables) using the option `Use Credentials` under `Other Authentication methods`.
+You can also login with Minio root credentials (which are set up in the environment variables in the `.env` file) using the option `Use Credentials` under `Other Authentication methods`.
 
 To create the access keys, in the MinIO console navigate to **_Access Keys -> Create access key_**
 

--- a/website/pages/five_safes_tes/reference_implementation/core_components.mdx
+++ b/website/pages/five_safes_tes/reference_implementation/core_components.mdx
@@ -82,7 +82,27 @@ There are three main components to operate with Camunda:
 ### Vault
 
 Vault is used to store and track the ephemeral user credentials for the credential management process.
-In short, Camunda will create the ephemeral user credentials and store them in Vault. Then, the TRE-Agent will retrieve the credentials from Vault to access the TRE's database.
+In short, Camunda will create the ephemeral user credentials and store them in Vault. Then, the TRE-Agent will retrieve the credentials from Vault, pass them to the Executor to access the TRE's database.
+
+In production, you need to setup Vault and generate a root token. Run the following commands one by one in the terminal to setup Vault using Docker interaction mode:
+
+```bash
+     docker compose up -d vault   # start only the Vault server
+     docker exec -it vault vault operator init -key-shares=1 -key-threshold=1  # this generates and shows on the console the unseal key and the initial root token
+     docker exec -it vault vault operator unseal <UNSEAL_KEY>  # unseal the vault
+     docker exec -it vault vault login <INITIAL_ROOT_TOKEN> # login to the vault
+     docker exec -it vault vault secrets enable -path=secret kv-v2 # enable the secret engine
+```
+
+Copy the generated root token and paste it into the `VaultRootToken` environment variable. Also, save the unseal key in a safe place to unseal the vault in the production mode.
+
+Then run `docker compose up -d` to start all the services.
+
+<Callout type="info">
+  After you restart the services using `docker compose up -d`, you may see the `vault` service keeps waiting. This is because the vault is not unsealed. 
+  To unseal the vault: On another terminal, run the following command: `docker exec -it vault vault operator unseal <UNSEAL_KEY>`.
+  After a few seconds, the `vault` service should start and other services will start as well.
+</Callout>
 
 ### LDAP (`openldap` and `phpldapadmin`)
 
@@ -147,4 +167,8 @@ TRE Agent MinIO, stores any inputs copied over from the Submission layer, and th
 ```yaml
 Username: minio
 Password: minio123
+```
+
+```
+
 ```

--- a/website/pages/submission/deploy.mdx
+++ b/website/pages/submission/deploy.mdx
@@ -170,6 +170,27 @@ The descriptions of the essential environment variables and the guide to set the
       </Td>
     </Tr>
     <Tr>
+      <Td>`KeycloakBootstrapAdminPassword`</Td>
+      <Td>
+        The bootstrap admin password for the Keycloak server used by the Submission Layer. This is used to bootstrap the Keycloak server with the admin user.
+        Default Keycloak bootstrap admin username is set to `admin`.
+      </Td>
+    </Tr>
+    <Tr>
+      <Td>`KeycloakStartupCommand`</Td>
+      <Td>
+        The command to start the Keycloak server. In dev mode (or Demostack), this is `start-dev`.
+        In production, if you have HTTPS configured for Keycloak, this should be set to `start`.
+      </Td>
+    </Tr>
+    <Tr>
+      <Td>`RabbitMQDefaultPassword`</Td>
+      <Td>
+        The default password for the RabbitMQ server used by the Submission Layer. Change this from the default value in production. 
+        Default RabbitMQ username is set to `rabbitmq`, and default RabbitMQ host is set to `rabbitmq`.
+      </Td>
+    </Tr>
+    <Tr>
       <Td>`SerilogLevel`</Td>
       <Td>
         The Serilog logging level for the Submission Layer. Default is `Information`. Change this depending on the logging level you want to set for the Submission Layer. More details [here](https://github.com/serilog/serilog/wiki/Configuration-Basics#minimum-level).

--- a/website/pages/submission/deploy.mdx
+++ b/website/pages/submission/deploy.mdx
@@ -197,16 +197,16 @@ The descriptions of the essential environment variables and the guide to set the
       </Td>
     </Tr>
     <Tr>
-      <Td>`KeycloakHostName`</Td>
+      <Td>`KeycloakFullURL`</Td>
       <Td>
-        The hostname of the Keycloak server. For example,
-        `my-keycloak`. This is only used if you are using a local Keycloak service defined in the `ServiceStack/compose-manifests/shared/auth.yml` file.
+        The full hostname URL of the Keycloak server, for example,`http://localhost:8085` or `https://my-keycloak.net`. 
+        This is only used if you are using a local/internal Keycloak service defined in the `ServiceStack/compose-manifests/shared/auth.yml` file.
       </Td>
     </Tr>
     <Tr>
       <Td>`SUBMISSION_KEYCLOAK_URL`</Td>
       <Td>
-        The URL of the Keycloak server. For example,
+        The URL of the Submission Layer's Keycloak server, for example,
         `http://keycloak:8080` (if using a local Keycloak server) or `https://my-submission-keycloak.net` (if using a remote Keycloak server).
       </Td>
     </Tr>
@@ -304,6 +304,7 @@ The descriptions of the essential environment variables and the guide to set the
         The path for the to the shared configuration files (e.g., realm config,
         init scripts) for the Submission Layer. Default is
         `../../../DeploymentStack/Submission/config`.
+        Change this if you are using a different path for the configuration files in your own deployment.
       </Td>
     </Tr>
         <Tr>

--- a/website/pages/tre_agent/deploy.mdx
+++ b/website/pages/tre_agent/deploy.mdx
@@ -223,7 +223,54 @@ The descriptions of the essential environment variables and the guide to set the
     <Tr>
       <Td>`PGLOGIN` and `PGPASSWORD`</Td>
       <Td>
-        The admin credentials for the PostgreSQL database used by the TRE Agent.
+        The admin credentials for the PostgreSQL database used by the TRE Agent. These are recommended to be changed from the default values.
+      </Td>
+    </Tr>
+    <Tr>
+      <Td>`LDAPAdminPassword` and `LDAPConfigPassword`</Td>
+      <Td>
+        The credentials for the OpenLDAP server used by the TRE Agent. These are recommended to be changed from the default values.
+      </Td>
+    </Tr>
+    <Tr>
+      <Td>`CamundaUsername` and `CamundaPassword`</Td>
+      <Td>
+        The credentials for the Camunda server used by the TRE Agent. These are recommended to be changed from the default values.
+      </Td>
+    </Tr>
+    <Tr>
+      <Td>`VaultStartupCommand`</Td>
+      <Td>
+        The command to start the Vault server. This is used to store and retrieve the ephemeral user credentials for the credential management process.
+        In production, this should be set to `vault server -config=/vault/config/config.json` to start the Vault server in the production mode. 
+        Setting up Vault server in production mode is required a few more steps detailed [here](/five_safes_tes/reference_implementation/core_components#vault).
+      </Td>
+    </Tr>
+    <Tr>
+      <Td>`VaultRootToken`</Td>
+      <Td>
+       In dev mode (or Demostack), this is pre-filled with a default value. 
+       In production, to generate a new root token, do the steps detailed [here](/five_safes_tes/reference_implementation/core_components#vault).
+      </Td>
+    </Tr>
+    <Tr>
+      <Td>`KeycloakBootstrapAdminPassword`</Td>
+      <Td>
+        The bootstrap admin password for the Keycloak server used by the TRE Agent. This is used to bootstrap the Keycloak server with the admin user.
+      </Td>
+    </Tr>
+    <Tr>
+      <Td>`KeycloakStartupCommand`</Td>
+      <Td>
+        The command to start the Keycloak server. In dev mode (or Demostack), this is `start-dev`.
+        In production, if you have HTTPS configured for Keycloak, this should be set to `start`.
+      </Td>
+    </Tr>
+    <Tr>
+      <Td>`RabbitMQDefaultPassword`</Td>
+      <Td>
+        The default password for the RabbitMQ server used by the TRE Agent. Change this from the default value in production. 
+        Default RabbitMQ username is set to `rabbitmq` and default RabbitMQ host is set to `rabbitmq`.
       </Td>
     </Tr>
     <Tr>

--- a/website/pages/tre_agent/deploy.mdx
+++ b/website/pages/tre_agent/deploy.mdx
@@ -309,23 +309,23 @@ The descriptions of the essential environment variables and the guide to set the
       </Td>
     </Tr>
     <Tr>
-      <Td>`KeycloakHostName`</Td>
+      <Td>`KeycloakFullURL`</Td>
       <Td>
-        The hostname of the Keycloak server, for example,`localhost` or `my-keycloak`. 
-        This is only used if you are using a local Keycloak service defined in the `ServiceStack/compose-manifests/shared/auth.yml` file.
+        The full hostname URL of the Keycloak server, for example,`http://localhost:8085` or `https://my-keycloak.net`. 
+        This is only used if you are using a local/internal Keycloak service defined in the `ServiceStack/compose-manifests/shared/auth.yml` file.
       </Td>
     </Tr>
     <Tr>
       <Td>`TRE_KEYCLOAK_URL`</Td>
       <Td>
-        The URL of the TRE Layer's Keycloak server. For example,
+        The URL of the TRE Layer's Keycloak server, for example,
         `http://keycloak:8080` (for default local Keycloak server) or `https://tre-keycloak.net` (for a remote Keycloak server).
       </Td>
     </Tr>
     <Tr>
       <Td>`SUBMISSION_KEYCLOAK_URL`</Td>
       <Td>
-        The URL of the Submission Layer's Keycloak server. For example,
+        The URL of the Submission Layer's Keycloak server, for example,
         `http://keycloak:8080` (for default local Keycloak server) or `https://submission-keycloak.net` (for a production Submission Layer Keycloak server).
       </Td>
     </Tr>
@@ -503,7 +503,8 @@ The descriptions of the essential environment variables and the guide to set the
       <Td>
         The path for the to the shared configuration files (e.g., realm config,
         ldap, vault, init scripts) for the TRE Layer. Default is
-        `../../../DeploymentStack/TRE/config`.
+        `../../../DeploymentStack/TRE/config`. 
+        Change this if you are using a different path for the configuration files in your own deployment.
       </Td>
     </Tr>
 

--- a/website/pages/tre_agent/deploy.mdx
+++ b/website/pages/tre_agent/deploy.mdx
@@ -591,6 +591,10 @@ Once a Submission layer Admin has created a Project, assigned Users to the Proje
 More details can be found in the [guide](/tre_agent/guides/TREManagerApprovingProject).
 
 
+#### Set up MinIO access key for TES Backend
+
+TES Backend (e.g., Funnel or TES-K) will need the access to TRE's Minio, so you would need to create a new access key in the Minio server (e.g., `<hostname>:9003`) and configure the TES Backend to use this access key. If you are using Funnel, you can follow this [guide](/five_safes_tes/reference_implementation/TES/install_funnel#set-up-minio-access-key) to set up the access key.
+
 #### Recommended next steps
 
 - Make sure TRE's containers, database and TES executing agent are running and accessible, then test the system by sending the [Hello world submission](/submission/tasks/quickstart#send-task) or [submission with basic analysis task](/submission/tasks/run_analysis#researchers-side-setup) from the Submission layer side.

--- a/website/pages/tre_agent/deploy.mdx
+++ b/website/pages/tre_agent/deploy.mdx
@@ -134,11 +134,6 @@ This can be done by setting the environment variables `TRE_DATA_USER` and `TRE_D
 
 - Docker and Docker Compose installed. For Linux/Ubuntu VMs, you can follow this [guide](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository)
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) installed on your machine.
-- TES executing agent (e.g., Funnel) installed and running.
-  <Callout>
-    Instructions on how to install Funnel can be found
-    [here](/five_safes_tes/reference_implementation/TES/install_funnel)
-  </Callout>
 
 ### Deployment Steps
 
@@ -341,7 +336,7 @@ The descriptions of the essential environment variables and the guide to set the
       <Td>
         Where TESK or Funnel API is hosted. For example,
         `http://host.docker.internal:8000/v1/tasks` (when Funnel is hosted
-        locally) or `http://my-funnel.com/tasks`.
+        locally) or `http://my-funnel.com/tasks`. This can be filled in with the URL of the TES executing agent (e.g., Funnel) after step 8 of this guide.
       </Td>
     </Tr>
     <Tr>
@@ -591,9 +586,14 @@ Once a Submission layer Admin has created a Project, assigned Users to the Proje
 More details can be found in the [guide](/tre_agent/guides/TREManagerApprovingProject).
 
 
-#### Set up MinIO access key for TES Backend
+#### Set up TES Backend and configure MinIO access key
 
-TES Backend (e.g., Funnel or TES-K) will need the access to TRE's Minio, so you would need to create a new access key in the Minio server (e.g., `<hostname>:9003`) and configure the TES Backend to use this access key. If you are using Funnel, you can follow this [guide](/five_safes_tes/reference_implementation/TES/install_funnel#set-up-minio-access-key) to set up the access key.
+- Install and run the TES executing agent (e.g., Funnel).
+<Callout type="info">
+  Instructions on how to install Funnel can be found
+  [here](/five_safes_tes/reference_implementation/TES/install_funnel)
+</Callout>
+- TES Backend (e.g., Funnel or TES-K) will need the access to TRE's Minio, so you would need to create a new access key in the Minio server (e.g., `<hostname>:9003`) and configure the TES Backend to use this access key. If you are using Funnel, you can follow this [guide](/five_safes_tes/reference_implementation/TES/install_funnel#set-up-minio-access-key) to set up the access key.
 
 #### Recommended next steps
 


### PR DESCRIPTION
This PR added docs to set up Vault service in prod mode and added descriptions about some new env vars, which can now be configured using `.env` files.

Also, this PR reorganised some steps in TRE's deployment section.