### PR TITLE
update to node 24 and GH workflow actions

### DIFF
--- a/.github/workflows/check.build.docs.yml
+++ b/.github/workflows/check.build.docs.yml
@@ -72,6 +72,6 @@ jobs:
           cp -r website/out docs/
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: docs

--- a/.github/workflows/check.build.docs.yml
+++ b/.github/workflows/check.build.docs.yml
@@ -2,7 +2,6 @@ name: Check Build Documentation Site
 
 on:
   pull_request:
-
     paths:
       - "website/**"
 
@@ -22,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Detect package manager
         id: detect-package-manager
@@ -43,15 +42,15 @@ jobs:
           fi
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .next/cache
@@ -76,4 +75,3 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: docs
-  

--- a/.github/workflows/check.build.docs.yml
+++ b/.github/workflows/check.build.docs.yml
@@ -72,6 +72,6 @@ jobs:
           cp -r website/out docs/
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs

--- a/.github/workflows/deploy.docs.yml
+++ b/.github/workflows/deploy.docs.yml
@@ -87,4 +87,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/deploy.docs.yml
+++ b/.github/workflows/deploy.docs.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Detect package manager
         id: detect-package-manager
@@ -45,15 +45,15 @@ jobs:
           fi
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .next/cache

--- a/.github/workflows/deploy.docs.yml
+++ b/.github/workflows/deploy.docs.yml
@@ -75,7 +75,7 @@ jobs:
           cp -r website/out docs/
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs
   deploy:

--- a/.github/workflows/deploy.docs.yml
+++ b/.github/workflows/deploy.docs.yml
@@ -75,7 +75,7 @@ jobs:
           cp -r website/out docs/
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: docs
   deploy:


### PR DESCRIPTION
Current actions run on node 20, which is being deprecated. See the warning message from GH:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/checkout@v4, actions/configure-pages@v5, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

This PR updates the GH workflow actions, and node version, so we can be future-proof.